### PR TITLE
Add user names to login response

### DIFF
--- a/frontend_microservice/templates/scripts.js
+++ b/frontend_microservice/templates/scripts.js
@@ -12,15 +12,16 @@ if (loginForm) {
       body: JSON.stringify({ email, password })
     })
     .then(response => response.json().then(data => ({ status: response.status, body: data })))
-    .then(({ status, body }) => {
-      if (status === 200) {
-        // Store user's first name in localStorage
-        localStorage.setItem('firstName', body.first_name || '');
-        alert(`Login successful! Welcome, ${body.first_name || 'User'}!`);
-        window.location.href = 'index.html';
-      } else {
-        alert(body.message || 'Login failed.');
-      }
+      .then(({ status, body }) => {
+        if (status === 200) {
+          // Store user's name in localStorage
+          localStorage.setItem('firstName', body.first_name || '');
+          localStorage.setItem('lastName', body.last_name || '');
+          alert(`Login successful! Welcome, ${body.first_name || 'User'}!`);
+          window.location.href = 'index.html';
+        } else {
+          alert(body.message || 'Login failed.');
+        }
     })
     .catch(error => {
       console.error('Login error:', error);

--- a/user_microservice/routes.py
+++ b/user_microservice/routes.py
@@ -54,7 +54,11 @@ def login_user():
     if not user or not user.check_password(password):
         return jsonify({"message": "Invalid email or password"}), 400
 
-    return jsonify({"message": f"Welcome {user.first_name} {user.last_name}!"}), 200
+    return jsonify({
+        "message": f"Welcome {user.first_name} {user.last_name}!",
+        "first_name": user.first_name,
+        "last_name": user.last_name
+    }), 200
 
 # ===============================
 # Password Reset Route


### PR DESCRIPTION
## Summary
- include `first_name` and `last_name` in login response
- persist both names in the login script

## Testing
- `python -m py_compile user_microservice/routes.py`


------
https://chatgpt.com/codex/tasks/task_e_684883f6bf248332adb5b9a681119df5