### PR TITLE
Remove hardcoded passwords

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+MYSQL_ROOT_PASSWORD=changeme
+MYSQL_PASSWORD=changeme

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 __pycache__/
 *.pyc
 user_microservice/users.db
+.env

--- a/README.md
+++ b/README.md
@@ -50,7 +50,9 @@ This project uses Docker Compose to orchestrate all microservices in isolated co
 git clone https://github.com/AadityaArunSingh/DealDeli.git
 cd DealDeli-final
 
-# Step 2: configure the database settings in the files according to your host and user credentials from MySql server 
+# Step 2: Copy `.env.example` to `.env` and update it with your MySQL credentials
+cp .env.example .env
+# Edit `.env` to set `MYSQL_ROOT_PASSWORD` and `MYSQL_PASSWORD`
 
 # Step 3: Start all services
 docker-compose up --build

--- a/analytics_microservice/db.py
+++ b/analytics_microservice/db.py
@@ -5,6 +5,6 @@ def get_connection():
     return mysql.connector.connect(
         host=os.getenv("MYSQL_HOST", "mysql_container"),
         user=os.getenv("MYSQL_USER", "root"),
-        password=os.getenv("MYSQL_PASSWORD", os.getenv("MYSQL_ROOT_PASSWORD", "UoS@2025")),
+        password=os.getenv("MYSQL_PASSWORD") or os.getenv("MYSQL_ROOT_PASSWORD"),
         database=os.getenv("MYSQL_DATABASE", "dealdeli_data")
     )

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     image: mysql:8.0
     container_name: mysql_container
     environment: &mysql_env
-      MYSQL_ROOT_PASSWORD: UoS@2025
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
       MYSQL_DATABASE: dealdeli_data
     ports:
       - "3306:3306"
@@ -35,7 +35,7 @@ services:
     environment:
       <<: *mysql_env
       MYSQL_USER: root
-      MYSQL_PASSWORD: UoS@2025
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD}
       MYSQL_HOST: mysql_container
     networks:
       - dealdeli-net
@@ -49,7 +49,7 @@ services:
       <<: *mysql_env
       MYSQL_HOST: mysql_container
       MYSQL_USER: root
-      MYSQL_PASSWORD: UoS@2025
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD}
     depends_on:
       - mysql_container
     networks:

--- a/price_microservice/app.py
+++ b/price_microservice/app.py
@@ -16,7 +16,7 @@ CORS(app, origins=["http://localhost:5501"])
 
 # Load from env or fallback
 user = os.getenv("MYSQL_USER", "root")
-password = quote_plus(os.getenv("MYSQL_PASSWORD", "UoS@2025"))  # Escape special chars
+password = quote_plus(os.getenv("MYSQL_PASSWORD") or os.getenv("MYSQL_ROOT_PASSWORD", ""))  # Escape special chars
 host = os.getenv("MYSQL_HOST", "mysql_container")
 db_name = os.getenv("MYSQL_DATABASE", "dealdeli_data")
 


### PR DESCRIPTION
## Summary
- strip hardcoded DB credentials from python code and docker compose
- use environment variables for credentials
- add `.env.example` and ignore `.env`
- document new env setup in README

## Testing
- `python3 -m compileall -q analytics_microservice price_microservice user_microservice frontend_microservice`
- `docker-compose --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684890a03d64833283661ef3a61b8988